### PR TITLE
Update cirq_version to cirq v1.3.0.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.venv
+.ipynb_checkpoints/
+__pycache__/

--- a/cirq_version/00_Course_Introduction.ipynb
+++ b/cirq_version/00_Course_Introduction.ipynb
@@ -65,7 +65,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -79,9 +79,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/cirq_version/00_Introduction_to_Cirq.ipynb
+++ b/cirq_version/00_Introduction_to_Cirq.ipynb
@@ -39,7 +39,7 @@
     "\n",
     "Once we define our algorithm in terms of gates and measurements, we need to execute the circuit. In Cirq, the simulators make a distinction between a \"run\" and a \"simulation\". A \"run\" mimics the actual quantum hardware and does not allow access to the amplitudes of the wave function of the system. A \"simulation\" allows for operations which would not be possible on hardware, such as examining the wave function.\n",
     "\n",
-    "Cirq comes with a simulator for generic gates that implements their unitary matrix, and there is also another simulator which is customized for the native gate set of Google's Xmon hardware:"
+    "Cirq comes with a simulator for generic gates that implements their unitary matrix, and which can also be adapted to specific devices using a gate set:"
    ]
   },
   {
@@ -48,8 +48,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from cirq import Simulator\n",
-    "from cirq.google import XmonSimulator"
+    "from cirq import Simulator"
    ]
   },
   {
@@ -84,7 +83,7 @@
    "outputs": [],
    "source": [
     "q = GridQubit(0,0)\n",
-    "circuit = Circuit.from_ops(\n",
+    "circuit = Circuit(\n",
     "    cirq.measure(q, key='m')\n",
     ")"
    ]
@@ -123,11 +122,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "circuit = Circuit.from_ops(\n",
-    "    cirq.SingleQubitMatrixGate(np.array([[1, 0], [0, 1]])).on(q)\n",
+    "circuit = Circuit(\n",
+    "    cirq.MatrixGate(np.array([[1, 0], [0, 1]])).on(q)\n",
     ")\n",
     "result = simulator.simulate(circuit)\n",
-    "print(result.final_state)"
+    "print(result.final_state_vector)"
    ]
   },
   {
@@ -158,7 +157,7 @@
    "outputs": [],
    "source": [
     "q = GridQubit(0,0)\n",
-    "circuit = Circuit.from_ops(\n",
+    "circuit = Circuit(\n",
     "    cirq.measure(q, key='m')\n",
     ")\n",
     "print(circuit.to_text_diagram())"
@@ -289,11 +288,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "circuit = Circuit.from_ops(\n",
+    "circuit = Circuit(\n",
     "    cirq.measure(q, key='m')\n",
     ")\n",
     "result = simulator.simulate(circuit)\n",
-    "plot_quantum_state(result.final_state)"
+    "plot_quantum_state(result.final_state_vector)"
    ]
   },
   {
@@ -309,13 +308,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "circuit = Circuit.from_ops(\n",
+    "circuit = Circuit(\n",
     "    cirq.H(q),\n",
     "    cirq.measure(q, key='m')\n",
     ")\n",
     "result = simulator.simulate(circuit)\n",
     "print(\"After a Hadamard gate\")\n",
-    "plot_quantum_state(result.final_state)"
+    "plot_quantum_state(result.final_state_vector)"
    ]
   },
   {
@@ -353,7 +352,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "circuit = Circuit.from_ops(\n",
+    "circuit = Circuit(\n",
     "    cirq.measure(q, key='m')\n",
     ")\n",
     "results = simulator.run(circuit, repetitions=1000)\n",
@@ -373,7 +372,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "circuit = Circuit.from_ops(\n",
+    "circuit = Circuit(\n",
     "    cirq.H(q),\n",
     "    cirq.measure(q, key='m')\n",
     ")\n",
@@ -391,7 +390,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -405,7 +404,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.10.12"
   },
   "varInspector": {
    "cols": {
@@ -438,5 +437,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/cirq_version/01_Classical_and_Quantum_Probability_Distributions.ipynb
+++ b/cirq_version/01_Classical_and_Quantum_Probability_Distributions.ipynb
@@ -271,7 +271,7 @@
     "\n",
     "q = GridQubit(0,0)\n",
     "circuit = Circuit()\n",
-    "circuit.append(cirq.SingleQubitMatrixGate(np.array([[1, 0], [0, 1]])).on(q))"
+    "circuit.append(cirq.MatrixGate(np.array([[1, 0], [0, 1]])).on(q))"
    ]
   },
   {
@@ -322,11 +322,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "circuit = Circuit.from_ops(\n",
+    "circuit = Circuit(\n",
     "    cirq.measure(q, key='m')\n",
     ")\n",
     "result = simulator.simulate(circuit)\n",
-    "plot_quantum_state(result.final_state)"
+    "plot_quantum_state(result.final_state_vector)"
    ]
   },
   {
@@ -344,8 +344,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "circuit = Circuit.from_ops(\n",
-    "    cirq.Ry(π/2).on(q),\n",
+    "circuit = Circuit(\n",
+    "    cirq.Ry(rads=π/2).on(q),\n",
     "    cirq.measure(q, key='m')\n",
     ")\n",
     "results = simulator.run(circuit, repetitions=100)\n",
@@ -365,11 +365,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "circuit = Circuit.from_ops(\n",
-    "    cirq.Ry(π/2).on(q)\n",
+    "circuit = Circuit(\n",
+    "    cirq.Ry(rads=π/2).on(q)\n",
     ")\n",
     "result = simulator.simulate(circuit)\n",
-    "plot_quantum_state(result.final_state)"
+    "plot_quantum_state(result.final_state_vector)"
    ]
   },
   {
@@ -387,12 +387,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "circuit = Circuit.from_ops(\n",
+    "circuit = Circuit(\n",
     "    cirq.X(q),\n",
-    "    cirq.Ry(π/2).on(q)\n",
+    "    cirq.Ry(rads=π/2).on(q)\n",
     ")\n",
     "result = simulator.simulate(circuit)\n",
-    "plot_quantum_state(result.final_state)"
+    "plot_quantum_state(result.final_state_vector)"
    ]
   },
   {
@@ -408,9 +408,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "circuit = Circuit.from_ops(\n",
+    "circuit = Circuit(\n",
     "    cirq.X(q),\n",
-    "    cirq.Ry(π/2).on(q),\n",
+    "    cirq.Ry(rads=π/2).on(q),\n",
     "    cirq.measure(q, key='m')\n",
     ")\n",
     "results = simulator.run(circuit, repetitions=100)\n",
@@ -430,9 +430,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "circuit = Circuit.from_ops(\n",
-    "    cirq.Ry(π/2).on(q),\n",
-    "    cirq.Ry(π/2).on(q),\n",
+    "circuit = Circuit(\n",
+    "    cirq.Ry(rads=π/2).on(q),\n",
+    "    cirq.Ry(rads=π/2).on(q),\n",
     "    cirq.measure(q, key='m')\n",
     ")\n",
     "results = simulator.run(circuit, repetitions=100)\n",
@@ -498,7 +498,7 @@
     "q0 = GridQubit(0,0)\n",
     "q1 = GridQubit(0,1)\n",
     "\n",
-    "circuit = Circuit.from_ops(\n",
+    "circuit = Circuit(\n",
     "    cirq.H(q0),\n",
     "    cirq.CNOT(q0, q1),\n",
     "    cirq.measure(q0, q1, key='m')\n",
@@ -526,7 +526,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -540,9 +540,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/cirq_version/02_Measurements_and_Mixed_States.ipynb
+++ b/cirq_version/02_Measurements_and_Mixed_States.ipynb
@@ -123,7 +123,7 @@
     "\n",
     "simulator = Simulator()\n",
     "q = GridQubit(0, 0)\n",
-    "circuit = Circuit.from_ops(\n",
+    "circuit = Circuit(\n",
     "    cirq.H(q),\n",
     "    cirq.measure(q, key='m')\n",
     ")\n",
@@ -167,7 +167,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "circuit = Circuit.from_ops(\n",
+    "circuit = Circuit(\n",
     "    cirq.H(q),\n",
     "    cirq.measure(q, key='m0'),\n",
     "    cirq.measure(q, key='m1')\n",
@@ -199,7 +199,7 @@
    "outputs": [],
    "source": [
     "q = [GridQubit(x, 0) for x in range(2)]\n",
-    "circuit = Circuit.from_ops(\n",
+    "circuit = Circuit(\n",
     "    cirq.H(q[0]),\n",
     "    cirq.measure(q[0], key='m0'),\n",
     "    cirq.measure(q[1], key='m1')\n",
@@ -222,7 +222,7 @@
    "outputs": [],
    "source": [
     "q = [GridQubit(x, 0) for x in range(2)]\n",
-    "circuit = Circuit.from_ops(\n",
+    "circuit = Circuit(\n",
     "    cirq.H(q[0]),\n",
     "    cirq.CNOT(q[0], q[1]),\n",
     "    cirq.measure(q[0], key='m0'),\n",
@@ -317,7 +317,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -331,9 +331,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/cirq_version/03_Evolution_in_Closed_and_Open_Systems.ipynb
+++ b/cirq_version/03_Evolution_in_Closed_and_Open_Systems.ipynb
@@ -89,13 +89,13 @@
     "\n",
     "simulator = Simulator()\n",
     "q = GridQubit(0, 0)\n",
-    "circuit = Circuit.from_ops(\n",
+    "circuit = Circuit(\n",
     "    cirq.X(q),\n",
     "    cirq.X(q),\n",
     "    cirq.measure(q, key='m')\n",
     ")\n",
     "result = simulator.simulate(circuit)\n",
-    "print(result.final_state)"
+    "print(result.final_state_vector)"
    ]
   },
   {
@@ -201,7 +201,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -215,9 +215,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/cirq_version/04_Classical_and_Quantum_Many-Body_Physics.ipynb
+++ b/cirq_version/04_Classical_and_Quantum_Many-Body_Physics.ipynb
@@ -302,12 +302,12 @@
    },
    "outputs": [],
    "source": [
-    "circuit = Circuit.from_ops(\n",
+    "circuit = Circuit(\n",
     "    cirq.Z(q),\n",
     "    cirq.measure(q, key='m')\n",
     ")\n",
     "result = simulator.simulate(circuit)\n",
-    "print(result.final_state)"
+    "print(result.final_state_vector)"
    ]
   },
   {
@@ -333,13 +333,13 @@
    },
    "outputs": [],
    "source": [
-    "circuit = Circuit.from_ops(\n",
+    "circuit = Circuit(\n",
     "    cirq.X(q),\n",
     "    cirq.Z(q),\n",
     "    cirq.measure(q, key='m')\n",
     ")\n",
     "result = simulator.simulate(circuit)\n",
-    "print(result.final_state)"
+    "print(result.final_state_vector)"
    ]
   },
   {
@@ -417,20 +417,20 @@
    },
    "outputs": [],
    "source": [
-    "circuit = Circuit.from_ops(\n",
+    "circuit = Circuit(\n",
     "    cirq.X(q),\n",
     "    cirq.Z(q),\n",
     "    cirq.measure(q, key='m')\n",
     ")\n",
     "result = simulator.simulate(circuit)\n",
-    "print(\"Pauli-X, then Pauli-Z:\", result.final_state)\n",
-    "circuit = Circuit.from_ops(\n",
+    "print(\"Pauli-X, then Pauli-Z:\", result.final_state_vector)\n",
+    "circuit = Circuit(\n",
     "    cirq.Z(q),\n",
     "    cirq.X(q),\n",
     "    cirq.measure(q, key='m')\n",
     ")\n",
     "result = simulator.simulate(circuit)\n",
-    "print(\"Pauli-Z, then Pauli-X:\", result.final_state)"
+    "print(\"Pauli-Z, then Pauli-X:\", result.final_state_vector)"
    ]
   },
   {
@@ -449,7 +449,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -463,7 +463,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.10.12"
   },
   "varInspector": {
    "cols": {
@@ -496,5 +496,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/cirq_version/05_Gate-Model_Quantum_Computing.ipynb
+++ b/cirq_version/05_Gate-Model_Quantum_Computing.ipynb
@@ -57,7 +57,7 @@
     "simulator = Simulator()\n",
     "q0, q1 = cirq.LineQubit.range(2)\n",
     "\n",
-    "circuit = Circuit.from_ops(\n",
+    "circuit = Circuit(\n",
     "     [cirq.H(q0), cirq.CNOT(q0, q1)]\n",
     ")\n",
     "print(circuit)"
@@ -91,7 +91,7 @@
    },
    "outputs": [],
    "source": [
-    "circuit.append([cirq.measure(q0), cirq.measure(q1)])\n",
+    "circuit.append([cirq.measure(q0, key='0'), cirq.measure(q1, key='1')])\n",
     "print(circuit)"
    ]
   },
@@ -101,6 +101,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "result = simulator.run(circuit, repetitions=100)\n",
     "result.multi_measurement_histogram(keys=['0','1'])"
    ]
   },
@@ -170,11 +171,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "line = cirq.google.line_on_device(cirq.google.Bristlecone, length=2)\n",
-    "translated = cirq.google.optimized_for_xmon(\n",
+    "import cirq_google\n",
+    "line = cirq_google.line_on_device(cirq_google.Sycamore, length=2)\n",
+    "translated = cirq.transformers.optimize_for_target_gateset(\n",
     "    circuit=circuit,\n",
-    "    new_device=cirq.google.Bristlecone,\n",
-    "    qubit_map=lambda q: line[q.x])\n",
+    "    gateset=cirq_google.SycamoreTargetGateset())\n",
     "print(translated)"
    ]
   },
@@ -190,7 +191,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -204,9 +205,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/cirq_version/06_Adiabatic_Quantum_Computing.ipynb
+++ b/cirq_version/06_Adiabatic_Quantum_Computing.ipynb
@@ -231,7 +231,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -245,9 +245,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/cirq_version/07_Variational_Circuits.ipynb
+++ b/cirq_version/07_Variational_Circuits.ipynb
@@ -291,9 +291,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "class ZZGate(cirq.ops.gate_features.TwoQubitGate):\n",
+    "class ZZGate(cirq.Gate):\n",
     "    def __init__(self, gamma):\n",
+    "        super(ZZGate, self)\n",
     "        self.gamma = gamma\n",
+    "\n",
+    "    def _num_qubits_(self):\n",
+    "        return 2\n",
     "    \n",
     "    def _decompose_(self, qubits):\n",
     "        a, b = qubits\n",
@@ -357,7 +361,7 @@
    },
    "outputs": [],
    "source": [
-    "print (circuit.to_unitary_matrix().round(5))\n",
+    "print (circuit.unitary().round(5))\n",
     "\n",
     "gamma = 0.1\n",
     "test_matrix = np.array([[np.exp(-1j*np.pi*gamma),0, 0, 0],\n",
@@ -436,7 +440,7 @@
     "def energy_from_params(betas, gammas):\n",
     "    sim = cirq.Simulator()\n",
     "    circuit = create_cirquit(betas, gammas)\n",
-    "    wf = sim.simulate(circuit).final_state\n",
+    "    wf = sim.simulate(circuit).final_state_vector\n",
     "    return -np.sum(np.abs(wf)**2 * np.array([1, -1, -1, 1])) \n",
     "\n",
     "def evaluate_circuit(beta_gamma):\n",
@@ -512,7 +516,7 @@
    },
    "outputs": [],
    "source": [
-    "wf = cirq.Simulator().simulate(circuit).final_state\n",
+    "wf = cirq.Simulator().simulate(circuit).final_state_vector\n",
     "wf"
    ]
   },
@@ -555,7 +559,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -569,9 +573,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/cirq_version/09_Discrete_Optimization_and_Ensemble_Learning.ipynb
+++ b/cirq_version/09_Discrete_Optimization_and_Ensemble_Learning.ipynb
@@ -1,978 +1,978 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.7.3"
-    },
-    "colab": {
-      "name": "09_Discrete_Optimization_and_Ensemble_Learning.ipynb",
-      "version": "0.3.2",
-      "provenance": [],
-      "collapsed_sections": []
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "RmcZZMAkKhZe"
+   },
+   "source": [
+    "Any learning algorithm will always have strengths and weaknesses: a single model is unlikely to fit every possible scenario. Ensembles combine multiple models to achieve higher generalization performance than any of the constituent models is capable of. How do we assemble the weak learners? We can use some sequential heuristics. For instance, given the current collection of models, we can add one more based on where that particular model performs well. Alternatively, we can look at all the correlations of the predictions between all models, and optimize for the most uncorrelated predictors. Since this latter is a global approach, it naturally maps to a quantum computer. But first, let's take a look a closer look at loss functions and regularization, two key concepts in machine learning."
+   ]
   },
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "RmcZZMAkKhZe",
-        "colab_type": "text"
-      },
-      "source": [
-        "Any learning algorithm will always have strengths and weaknesses: a single model is unlikely to fit every possible scenario. Ensembles combine multiple models to achieve higher generalization performance than any of the constituent models is capable of. How do we assemble the weak learners? We can use some sequential heuristics. For instance, given the current collection of models, we can add one more based on where that particular model performs well. Alternatively, we can look at all the correlations of the predictions between all models, and optimize for the most uncorrelated predictors. Since this latter is a global approach, it naturally maps to a quantum computer. But first, let's take a look a closer look at loss functions and regularization, two key concepts in machine learning."
-      ]
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "rISgg0t1KhZg"
+   },
+   "source": [
+    "# Loss Functions and Regularization\n",
+    "\n",
+    "If you can solve a problem by a classical computer -- let that be a laptop or a massive GPU cluster -- there is little value in solving it by a quantum computer that costs ten million dollars. The interesting question in quantum machine learning is whether there are problems in machine learning and AI that fit quantum computers naturally, but are challenging on classical hardware. This, however, requires a good understanding of both machine learning and contemporary quantum computers.\n",
+    "\n",
+    "In this course, we primarily focus on the second aspect, since there is no shortage of educational material on classical machine learning. However, it is worth spending a few minutes on going through some basics.\n",
+    "\n",
+    "Let us take a look at the easiest possible problem: the data points split into two, easily distinguishable sets. We randomly generate this data set:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "3sk_MFmlKhZh"
+   },
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "%matplotlib inline\n",
+    "\n",
+    "c1 = np.random.rand(50, 2)/5\n",
+    "c2 = (-0.6, 0.5) + np.random.rand(50, 2)/5\n",
+    "data = np.concatenate((c1, c2))\n",
+    "labels = np.array([0] * 50 + [1] *50)\n",
+    "plt.figure(figsize=(6, 6))\n",
+    "plt.subplot(111, xticks=[], yticks=[])\n",
+    "plt.scatter(data[:50, 0], data[:50, 1], color='navy')\n",
+    "plt.scatter(data[50:, 0], data[50:, 1], color='c')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "oTNcpyBlKhZl"
+   },
+   "source": [
+    "Let's shuffle the data set into a training set that we are going to optimize over (2/3 of the data), and a test set where we estimate our generalization performance. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "ZjbyGDztKhZm"
+   },
+   "outputs": [],
+   "source": [
+    "idx = np.arange(len(labels))\n",
+    "np.random.shuffle(idx)\n",
+    "# train on a random 2/3 and test on the remaining 1/3\n",
+    "idx_train = idx[:2*len(idx)//3]\n",
+    "idx_test = idx[2*len(idx)//3:]\n",
+    "X_train = data[idx_train]\n",
+    "X_test = data[idx_test]\n",
+    "y_train = labels[idx_train]\n",
+    "y_test = labels[idx_test]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "lbD6WDVoKhZp"
+   },
+   "source": [
+    "We will use the package `scikit-learn` to train various machine learning models."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "i4HtnYbUKhZq"
+   },
+   "outputs": [],
+   "source": [
+    "import sklearn\n",
+    "import sklearn.metrics\n",
+    "metric = sklearn.metrics.accuracy_score"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "Cz4mnkJ6KhZt"
+   },
+   "source": [
+    "Let's train a perceptron, which has a linear loss function $\\frac{1}{N}\\sum_{i=1}^N |h(x_i)-y_i)|$:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "yLL9tU94KhZu"
+   },
+   "outputs": [],
+   "source": [
+    "from sklearn.linear_model import Perceptron\n",
+    "model_1 = Perceptron(max_iter=1000, tol=1e-3)\n",
+    "model_1.fit(X_train, y_train)\n",
+    "print('accuracy (train): %5.2f'%(metric(y_train, model_1.predict(X_train))))\n",
+    "print('accuracy (test): %5.2f'%(metric(y_test, model_1.predict(X_test))))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "Gv-CXNCiKhZx"
+   },
+   "source": [
+    "It does a great job. It is a linear model, meaning its decision surface is a plane. Our dataset is separable by a plane, so let's try another linear model, but this time a support vector machine. If you eyeball our dataset, you will see that to define the separation between the two classes, actually only a few points close to the margin are relevant. These are called support vectors and support vector machines aim to find them. Its objective function measures the loss and it has a regularization term with a weight $C$. The $C$ hyperparameter controls a regularization term that penalizes the objective for the number of support vectors:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "9Hmuoj8fKhZy"
+   },
+   "outputs": [],
+   "source": [
+    "from sklearn.svm import SVC\n",
+    "model_2 = SVC(kernel='linear', C=10)\n",
+    "model_2.fit(X_train, y_train)\n",
+    "print('accuracy (train): %5.2f'%(metric(y_train, model_2.predict(X_train))))\n",
+    "print('accuracy (test): %5.2f'%(metric(y_test, model_2.predict(X_test))))\n",
+    "print('Number of support vectors:', sum(model_2.n_support_))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "FHdbpqZNKhZ1"
+   },
+   "source": [
+    "It picks only two datapoints out of the hundred. Let's change the hyperparameter to reduce the penalty:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "YYdfktBrKhZ2"
+   },
+   "outputs": [],
+   "source": [
+    "model_2 = SVC(kernel='linear', C=0.01)\n",
+    "model_2.fit(X_train, y_train)\n",
+    "print('accuracy (train): %5.2f'%(metric(y_train, model_2.predict(X_train))))\n",
+    "print('accuracy (test): %5.2f'%(metric(y_test, model_2.predict(X_test))))\n",
+    "print('Number of support vectors:', sum(model_2.n_support_))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "dsSsMDWUKhZ8"
+   },
+   "source": [
+    "You can see that the model gets confused by using too many datapoints in the final classifier. This is one example where regularization helps."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "p5jtrNZ0KhZ9"
+   },
+   "source": [
+    "# Ensemble methods\n",
+    "\n",
+    "Ensembles yield better results when there is considerable diversity among the base classifiers. If diversity is sufficient, base classifiers make different errors, and a strategic combination may reduce the total error, ideally improving generalization performance. A constituent model in an ensemble is also called a base classifier or weak learner, and the composite model a strong learner.\n",
+    "\n",
+    "The generic procedure of ensemble methods has two steps. First, develop a set of base classifiers from the training data. Second, combine them to form the ensemble. In the simplest combination, the base learners vote, and the label prediction is based on majority. More involved methods weigh the votes of the base learners. \n",
+    "\n",
+    "Let us import some packages and define our figure of merit as accuracy in a balanced dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2018-11-19T20:10:18.000793Z",
+     "start_time": "2018-11-19T20:10:17.128450Z"
     },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "rISgg0t1KhZg",
-        "colab_type": "text"
-      },
-      "source": [
-        "# Loss Functions and Regularization\n",
-        "\n",
-        "If you can solve a problem by a classical computer -- let that be a laptop or a massive GPU cluster -- there is little value in solving it by a quantum computer that costs ten million dollars. The interesting question in quantum machine learning is whether there are problems in machine learning and AI that fit quantum computers naturally, but are challenging on classical hardware. This, however, requires a good understanding of both machine learning and contemporary quantum computers.\n",
-        "\n",
-        "In this course, we primarily focus on the second aspect, since there is no shortage of educational material on classical machine learning. However, it is worth spending a few minutes on going through some basics.\n",
-        "\n",
-        "Let us take a look at the easiest possible problem: the data points split into two, easily distinguishable sets. We randomly generate this data set:"
-      ]
+    "colab": {},
+    "colab_type": "code",
+    "id": "BRdEHzfcKhZ-"
+   },
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import sklearn\n",
+    "import sklearn.datasets\n",
+    "import sklearn.metrics\n",
+    "%matplotlib inline\n",
+    "\n",
+    "metric = sklearn.metrics.accuracy_score"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "kivZQgMOKhaC"
+   },
+   "source": [
+    "We generate a random dataset of two classes that form concentric circles:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2018-11-19T20:10:18.174692Z",
+     "start_time": "2018-11-19T20:10:18.003641Z"
     },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "3sk_MFmlKhZh",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "import matplotlib.pyplot as plt\n",
-        "import numpy as np\n",
-        "%matplotlib inline\n",
-        "\n",
-        "c1 = np.random.rand(50, 2)/5\n",
-        "c2 = (-0.6, 0.5) + np.random.rand(50, 2)/5\n",
-        "data = np.concatenate((c1, c2))\n",
-        "labels = np.array([0] * 50 + [1] *50)\n",
-        "plt.figure(figsize=(6, 6))\n",
-        "plt.subplot(111, xticks=[], yticks=[])\n",
-        "plt.scatter(data[:50, 0], data[:50, 1], color='navy')\n",
-        "plt.scatter(data[50:, 0], data[50:, 1], color='c')"
-      ],
-      "execution_count": 0,
-      "outputs": []
+    "colab": {},
+    "colab_type": "code",
+    "id": "gSzdAIAxKhaD"
+   },
+   "outputs": [],
+   "source": [
+    "np.random.seed(0)\n",
+    "data, labels = sklearn.datasets.make_circles()\n",
+    "idx = np.arange(len(labels))\n",
+    "np.random.shuffle(idx)\n",
+    "# train on a random 2/3 and test on the remaining 1/3\n",
+    "idx_train = idx[:2*len(idx)//3]\n",
+    "idx_test = idx[2*len(idx)//3:]\n",
+    "X_train = data[idx_train]\n",
+    "X_test = data[idx_test]\n",
+    "\n",
+    "y_train = 2 * labels[idx_train] - 1  # binary -> spin\n",
+    "y_test = 2 * labels[idx_test] - 1\n",
+    "\n",
+    "scaler = sklearn.preprocessing.StandardScaler()\n",
+    "normalizer = sklearn.preprocessing.Normalizer()\n",
+    "\n",
+    "X_train = scaler.fit_transform(X_train)\n",
+    "X_train = normalizer.fit_transform(X_train)\n",
+    "\n",
+    "X_test = scaler.fit_transform(X_test)\n",
+    "X_test = normalizer.fit_transform(X_test)\n",
+    "plt.figure(figsize=(6, 6))\n",
+    "plt.subplot(111, xticks=[], yticks=[])\n",
+    "plt.scatter(data[labels == 0, 0], data[labels == 0, 1], color='navy')\n",
+    "plt.scatter(data[labels == 1, 0], data[labels == 1, 1], color='c')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "gIh74UIkKhaF"
+   },
+   "source": [
+    "Let's train a perceptron:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2018-11-19T20:10:18.226327Z",
+     "start_time": "2018-11-19T20:10:18.177561Z"
     },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "oTNcpyBlKhZl",
-        "colab_type": "text"
-      },
-      "source": [
-        "Let's shuffle the data set into a training set that we are going to optimize over (2/3 of the data), and a test set where we estimate our generalization performance. "
-      ]
+    "colab": {},
+    "colab_type": "code",
+    "id": "kv4kPmcAKhaG"
+   },
+   "outputs": [],
+   "source": [
+    "from sklearn.linear_model import Perceptron\n",
+    "model_1 = Perceptron(max_iter=1000, tol=1e-3)\n",
+    "model_1.fit(X_train, y_train)\n",
+    "print('accuracy (train): %5.2f'%(metric(y_train, model_1.predict(X_train))))\n",
+    "print('accuracy (test): %5.2f'%(metric(y_test, model_1.predict(X_test))))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "zfqHpvzWKhaJ"
+   },
+   "source": [
+    "Since its decision surface is linear, we get a poor accuracy. Would a support vector machine with a nonlinear kernel fare better?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2018-11-19T20:10:18.244639Z",
+     "start_time": "2018-11-19T20:10:18.230025Z"
     },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "ZjbyGDztKhZm",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "idx = np.arange(len(labels))\n",
-        "np.random.shuffle(idx)\n",
-        "# train on a random 2/3 and test on the remaining 1/3\n",
-        "idx_train = idx[:2*len(idx)//3]\n",
-        "idx_test = idx[2*len(idx)//3:]\n",
-        "X_train = data[idx_train]\n",
-        "X_test = data[idx_test]\n",
-        "y_train = labels[idx_train]\n",
-        "y_test = labels[idx_test]"
-      ],
-      "execution_count": 0,
-      "outputs": []
+    "colab": {},
+    "colab_type": "code",
+    "id": "bdiY9DXQKhaK"
+   },
+   "outputs": [],
+   "source": [
+    "from sklearn.svm import SVC\n",
+    "model_2 = SVC(kernel='rbf', gamma='auto')\n",
+    "model_2.fit(X_train, y_train)\n",
+    "print('accuracy (train): %5.2f'%(metric(y_train, model_2.predict(X_train))))\n",
+    "print('accuracy (test): %5.2f'%(metric(y_test, model_2.predict(X_test))))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "sikwlkiXKhaM"
+   },
+   "source": [
+    "It performs better on the training set, but at the cost of extremely poor generalization. \n",
+    "\n",
+    "Boosting is an ensemble method that explicitly seeks models that complement one another. The variation between boosting algorithms is how they combine weak learners. Adaptive boosting (AdaBoost) is a popular method that combines the weak learners in a sequential manner based on their individual accuracies. It has a convex objective function that does not penalize for complexity: it is likely to include all available weak learners in the final ensemble. Let's train AdaBoost with a few weak learners:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2018-11-19T20:10:18.314089Z",
+     "start_time": "2018-11-19T20:10:18.248869Z"
     },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "lbD6WDVoKhZp",
-        "colab_type": "text"
-      },
-      "source": [
-        "We will use the package `scikit-learn` to train various machine learning models."
-      ]
+    "colab": {},
+    "colab_type": "code",
+    "id": "03ZoTjmMKhaN"
+   },
+   "outputs": [],
+   "source": [
+    "from sklearn.ensemble import AdaBoostClassifier\n",
+    "model_3 = AdaBoostClassifier(n_estimators=3)\n",
+    "model_3.fit(X_train, y_train)\n",
+    "print('accuracy (train): %5.2f'%(metric(y_train, model_3.predict(X_train))))\n",
+    "print('accuracy (test): %5.2f'%(metric(y_test, model_3.predict(X_test))))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "9hVpr05sKhaQ"
+   },
+   "source": [
+    "Its performance is marginally better than that of the SVM."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "sos7cXfGKhaQ"
+   },
+   "source": [
+    "# QBoost\n",
+    "\n",
+    "The idea of Qboost is that optimization on a quantum computer is not constrained to convex objective functions, therefore we can add arbitrary penalty terms and rephrase our objective [[1](#1)]. Qboost solves the following problem:\n",
+    "\n",
+    "$$\n",
+    "\\mathrm{argmin}_{w} \\left(\\frac{1}{N}\\sum_{i=1}^{N}\\left(\\sum_{k=1}^{K}w_kh_k(x_i)-\n",
+    "y_i\\right)^2+\\lambda\\|w\\|_0\\right),\n",
+    "$$\n",
+    "\n",
+    "where $h_k(x_i)$ is the prediction of the weak learner $k$ for a training instance $k$. The weights in this formulation are binary, so this objective function already maps to an Ising model. The regularization in the $l_0$ norm ensures sparsity, and it is not the kind of regularization we would consider classically: it is hard to optimize with this term on a digital computer.\n",
+    "\n",
+    "Let us expand the quadratic part of the objective:\n",
+    "\n",
+    "$$\n",
+    "\\mathrm{argmin}_{w} \\left(\\frac{1}{N}\\sum_{i=1}^{N}\n",
+    "\\left( \\left(\\sum_{k=1}^{K} w_k h_k(x_i)\\right)^{2} -\n",
+    "2\\sum_{k=1}^{K} w_k h_k(\\mathbf{x}_i)y_i + y_i^{2}\\right) + \\lambda \\|w\\|_{0}\n",
+    "\\right).\n",
+    "$$\n",
+    "\n",
+    "Since $y_i^{2}$ is just a constant offset, the optimization reduces to\n",
+    "\n",
+    "$$\n",
+    "\\mathrm{argmin}_{w} \\left(\n",
+    "\\frac{1}{N}\\sum_{k=1}^{K}\\sum_{l=1}^{K} w_k w_l\n",
+    "\\left(\\sum_{i=1}^{N}h_k(x_i)h_l(x_i)\\right) - \n",
+    "\\frac{2}{N}\\sum_{k=1}^{K}w_k\\sum_{i=1}^{N} h_k(x_i)y_i +\n",
+    "\\lambda \\|w\\|_{0} \\right).\n",
+    "$$\n",
+    "\n",
+    "This form shows that we consider all correlations between the predictions of the weak learners: there is a summation of $h_k(x_i)h_l(x_i)$. Since this term has a positive sign, we penalize for correlations. On the other hand, the correlation with the true label, $h_k(x_i)y_i$, has a negative sign. The regularization term remains unchanged.\n",
+    "\n",
+    "\n",
+    "\n",
+    "To run this on an annealing machine we discretize this equation, reduce the weights to single bits, and normalize the estimator by K to scale with the feature data. As the weights are single bit, the regularization term becomes a summation that allows us to turn the expression into a QUBO.\n",
+    "\n",
+    "$$\n",
+    "\\mathrm{argmin}_{w} \\sum_{k=1}^{K} \\sum_{l=1}^{K}  w_kw_l \\sum_{i=1}^{N}\\frac{1}{K^2}h_k(x_i)h_l(x_i) + \\sum_{k=1}^{K}w_k \\left(\\lambda-2\\sum_{i=1}^{N} \\frac{1}{K}h_k(x_i)y_i   \\right), \\mathrm{w}_k \\in \\{0,1\\}\n",
+    "$$\n",
+    "\n",
+    "We split off the diagonal coefficients (k=l) in the left term and since $\\mathrm {w}\\in \\{0,1\\}$, and predictions, $\\mathrm h_k(x_i) \\in\\{-1,1\\}$ the following holds:\n",
+    "\n",
+    "$$\n",
+    "w_kw_k = w_k,\\;h_k(x_i)h_k(x_i) = 1\n",
+    "$$\n",
+    "\n",
+    "Hence:\n",
+    "\n",
+    "\n",
+    "$$\n",
+    "\\mathrm \\sum_{k=1}^{K}  w_kw_k \\sum_{i=1}^{N}\\frac{1}{K^2}h_k(x_i)h_k(x_i) = \\sum_{k=1}^{K}  w_k \\frac{N}{K^2}\n",
+    "$$\n",
+    "\n",
+    "This last term is effectively a fixed offset to $\\lambda $ \n",
+    "\n",
+    "$$\n",
+    "\\mathrm{argmin}_{w} \\sum_{k\\neq1}^{K}  w_kw_l \\left(\\sum_{i=1}^{N}\\frac{1}{K^2}h_k(x_i)h_l(x_i)\\right) + \\sum_{k=1}^{K}w_k \\left(\\frac{N}{K^2} +\\lambda-2\\sum_{i=1}^{N} \\frac{1}{K}h_k(x_i)y_i   \\right), \\mathrm{w}_k \\in \\{0,1\\}\n",
+    "$$\n",
+    "\n",
+    "The expressions between brackets are the coeficients of the QUBO\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "_g4dRvIEKhaR"
+   },
+   "source": [
+    "\n",
+    "Let us consider all three models from the previous section as weak learners."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2018-11-19T20:10:18.320974Z",
+     "start_time": "2018-11-19T20:10:18.316633Z"
     },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "i4HtnYbUKhZq",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "import sklearn\n",
-        "import sklearn.metrics\n",
-        "metric = sklearn.metrics.accuracy_score"
-      ],
-      "execution_count": 0,
-      "outputs": []
+    "colab": {},
+    "colab_type": "code",
+    "id": "7Xaw2_zEKhaS"
+   },
+   "outputs": [],
+   "source": [
+    "models = [model_1, model_2, model_3]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "BbvGvIT8KhaV"
+   },
+   "source": [
+    "We calculate their predictions and set $\\lambda$ to 1. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2018-11-19T20:10:18.354723Z",
+     "start_time": "2018-11-19T20:10:18.323802Z"
     },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Cz4mnkJ6KhZt",
-        "colab_type": "text"
-      },
-      "source": [
-        "Let's train a perceptron, which has a linear loss function $\\frac{1}{N}\\sum_{i=1}^N |h(x_i)-y_i)|$:"
-      ]
+    "colab": {},
+    "colab_type": "code",
+    "id": "ePyav5gxKhaW"
+   },
+   "outputs": [],
+   "source": [
+    "n_models = len(models)\n",
+    "predictions = np.array([h.predict(X_train) for h in models], dtype=np.float64)\n",
+    "λ = 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "b8R8AnjQKhaY"
+   },
+   "source": [
+    "We create the quadratic binary optimization of the objective function as we expanded above.\n",
+    "First the off-diagonal elements (see DWave's documentation for the sample_qubo() method ):\n",
+    "\n",
+    "$$\n",
+    "q_{ij} = \\sum_{i=1}^{N}\\frac{1}{K^2}h_k(x_i)h_l(x_i) \n",
+    "$$\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2018-11-19T20:10:18.375760Z",
+     "start_time": "2018-11-19T20:10:18.357248Z"
     },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "yLL9tU94KhZu",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "from sklearn.linear_model import Perceptron\n",
-        "model_1 = Perceptron(max_iter=1000, tol=1e-3)\n",
-        "model_1.fit(X_train, y_train)\n",
-        "print('accuracy (train): %5.2f'%(metric(y_train, model_1.predict(X_train))))\n",
-        "print('accuracy (test): %5.2f'%(metric(y_test, model_1.predict(X_test))))"
-      ],
-      "execution_count": 0,
-      "outputs": []
+    "colab": {},
+    "colab_type": "code",
+    "id": "AwhlEflrKhaZ"
+   },
+   "outputs": [],
+   "source": [
+    "q = predictions @ predictions.T/(n_models ** 2)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "_EGVfq2xKhac"
+   },
+   "source": [
+    "Then the diagonal elements:\n",
+    "\n",
+    "$$\n",
+    "\\mathrm q_{ii} =\\frac{N}{K^2}+ \\lambda-2\\sum_{i=1}^{N} \\frac{1}{K}h_k(x_i)y_i\n",
+    "$$\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "UyFXB6bvKhad"
+   },
+   "outputs": [],
+   "source": [
+    "qii = len(X_train) / (n_models ** 2) + λ - 2 * predictions @ y_train/(n_models)\n",
+    "\n",
+    "q[np.diag_indices_from(q)] = qii\n",
+    "Q = {}\n",
+    "for i in range(n_models):\n",
+    "    for j in range(i, n_models):\n",
+    "        Q[(i, j)] = q[i, j]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "SpVm_3aJKhai"
+   },
+   "source": [
+    "We solve the quadratic binary optimization with simulated annealing and read out the optimal weights:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2018-11-19T20:10:18.703378Z",
+     "start_time": "2018-11-19T20:10:18.378217Z"
     },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Gv-CXNCiKhZx",
-        "colab_type": "text"
-      },
-      "source": [
-        "It does a great job. It is a linear model, meaning its decision surface is a plane. Our dataset is separable by a plane, so let's try another linear model, but this time a support vector machine. If you eyeball our dataset, you will see that to define the separation between the two classes, actually only a few points close to the margin are relevant. These are called support vectors and support vector machines aim to find them. Its objective function measures the loss and it has a regularization term with a weight $C$. The $C$ hyperparameter controls a regularization term that penalizes the objective for the number of support vectors:"
-      ]
+    "colab": {},
+    "colab_type": "code",
+    "id": "YzMtHbZ2Khaj"
+   },
+   "outputs": [],
+   "source": [
+    "import dimod\n",
+    "sampler = dimod.SimulatedAnnealingSampler()\n",
+    "response = sampler.sample_qubo(Q, num_reads=10)\n",
+    "weights = list(response.first.sample.values())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "QVTjUyn2Khan"
+   },
+   "source": [
+    "We define a prediction function to help with measuring accuracy:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2018-11-19T20:10:18.715360Z",
+     "start_time": "2018-11-19T20:10:18.705496Z"
     },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "9Hmuoj8fKhZy",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "from sklearn.svm import SVC\n",
-        "model_2 = SVC(kernel='linear', C=10)\n",
-        "model_2.fit(X_train, y_train)\n",
-        "print('accuracy (train): %5.2f'%(metric(y_train, model_2.predict(X_train))))\n",
-        "print('accuracy (test): %5.2f'%(metric(y_test, model_2.predict(X_test))))\n",
-        "print('Number of support vectors:', sum(model_2.n_support_))"
-      ],
-      "execution_count": 0,
-      "outputs": []
+    "colab": {},
+    "colab_type": "code",
+    "id": "Qq3jT-8MKhao"
+   },
+   "outputs": [],
+   "source": [
+    "def predict(models, weights, X):\n",
+    "\n",
+    "    n_data = len(X)\n",
+    "    T = 0\n",
+    "    y = np.zeros(n_data)\n",
+    "    for i, h in enumerate(models):\n",
+    "        y0 = weights[i] * h.predict(X)  # prediction of weak classifier\n",
+    "        y += y0\n",
+    "        T += np.sum(y0)\n",
+    "\n",
+    "    y = np.sign(y - T / (n_data*len(models)))\n",
+    "\n",
+    "    return y"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2018-11-19T20:10:18.734604Z",
+     "start_time": "2018-11-19T20:10:18.719931Z"
     },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "FHdbpqZNKhZ1",
-        "colab_type": "text"
-      },
-      "source": [
-        "It picks only two datapoints out of the hundred. Let's change the hyperparameter to reduce the penalty:"
-      ]
+    "colab": {},
+    "colab_type": "code",
+    "id": "3NDHjGUIKhar"
+   },
+   "outputs": [],
+   "source": [
+    "print('accuracy (train): %5.2f'%(metric(y_train, predict(models, weights, X_train))))\n",
+    "print('accuracy (test): %5.2f'%(metric(y_test, predict(models, weights, X_test))))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "-2K7jt1SKhat"
+   },
+   "source": [
+    "The accuracy co-incides with our strongest weak learner's, the AdaBoost model. Looking at the optimal weights, this is apparent:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2018-11-19T20:10:18.751765Z",
+     "start_time": "2018-11-19T20:10:18.736771Z"
     },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "YYdfktBrKhZ2",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "model_2 = SVC(kernel='linear', C=0.01)\n",
-        "model_2.fit(X_train, y_train)\n",
-        "print('accuracy (train): %5.2f'%(metric(y_train, model_2.predict(X_train))))\n",
-        "print('accuracy (test): %5.2f'%(metric(y_test, model_2.predict(X_test))))\n",
-        "print('Number of support vectors:', sum(model_2.n_support_))"
-      ],
-      "execution_count": 0,
-      "outputs": []
+    "colab": {},
+    "colab_type": "code",
+    "id": "72BFrpqjKhav"
+   },
+   "outputs": [],
+   "source": [
+    "weights"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "e1G6CU6KKhax"
+   },
+   "source": [
+    "Only AdaBoost made it to the final ensemble. The first two models perform poorly and their predictions are correlated. Yet, if you remove regularization by setting $\\lambda=0$ above, the second model also enters the ensemble, decreasing overall performance. This shows that the regularization is in fact important."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "4DxoQ9CnKhay"
+   },
+   "source": [
+    "# Solving by QAOA\n",
+    "\n",
+    "Since eventually our problem is just an Ising model, we can also solve it on a gate-model quantum computer by QAOA. Let us explicitly map the binary optimization to the Ising model:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2018-11-19T20:10:18.765328Z",
+     "start_time": "2018-11-19T20:10:18.754605Z"
     },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "dsSsMDWUKhZ8",
-        "colab_type": "text"
-      },
-      "source": [
-        "You can see that the model gets confused by using too many datapoints in the final classifier. This is one example where regularization helps."
-      ]
+    "colab": {},
+    "colab_type": "code",
+    "id": "xSUgYnpjKhaz"
+   },
+   "outputs": [],
+   "source": [
+    "h, J, offset = dimod.qubo_to_ising(Q)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "kGPlqhItKha1"
+   },
+   "source": [
+    "We have to translate the Ising couplings to be suitable for solving by the QAOA routine.  The following will create the QAOA circuit with functions from lesson 07 and initialize the QAOA circuit with initial values for beta and gamma."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "sPl5ZzTf2jeJ"
+   },
+   "outputs": [],
+   "source": [
+    "import cirq\n",
+    "import numpy as np\n",
+    "from scipy.optimize import minimize\n",
+    "\n",
+    "qubits = cirq.LineQubit(i).range(q.shape[0])\n",
+    "num_nodes = len(qubits)\n",
+    "\n",
+    "def initial_layer(qubits):\n",
+    "    yield cirq.H.on_each(qubits)\n",
+    "\n",
+    "def beta_layer(beta, qubits):\n",
+    "    yield (cirq.X**(-beta)).on_each(qubits)\n",
+    "\n",
+    "def gamma_layer(gamma, qubits):\n",
+    "  for i in range(num_nodes):\n",
+    "    z_i = cirq.Z(qubits[i])\n",
+    "    yield np.exp(z_i * h[i] * gamma * 1j)\n",
+    "    for j in range(i+1, num_nodes):\n",
+    "        if q[i, j] != 0:\n",
+    "            z_j = cirq.Z(qubits[j])\n",
+    "            yield np.exp(z_i * z_j * J[i, j] * gamma * 1j)\n",
+    "\n",
+    "def create_cirquit(beta, gamma):\n",
+    "    return cirq.Circuit(initial_layer(qubits),\n",
+    "                        beta_layer(beta, qubits),\n",
+    "                        gamma_layer(gamma, qubits))\n",
+    "\n",
+    "beta = np.random.uniform(0, 2 * np.pi)\n",
+    "gamma = np.random.uniform(0, 2 * np.pi)\n",
+    "circuit = create_cirquit(beta, gamma)\n",
+    "print(circuit)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "UyfJTMppKha3"
+   },
+   "source": [
+    "Next we run the optimization:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2018-11-19T20:10:40.568546Z",
+     "start_time": "2018-11-19T20:10:19.840830Z"
     },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "p5jtrNZ0KhZ9",
-        "colab_type": "text"
-      },
-      "source": [
-        "# Ensemble methods\n",
-        "\n",
-        "Ensembles yield better results when there is considerable diversity among the base classifiers. If diversity is sufficient, base classifiers make different errors, and a strategic combination may reduce the total error, ideally improving generalization performance. A constituent model in an ensemble is also called a base classifier or weak learner, and the composite model a strong learner.\n",
-        "\n",
-        "The generic procedure of ensemble methods has two steps. First, develop a set of base classifiers from the training data. Second, combine them to form the ensemble. In the simplest combination, the base learners vote, and the label prediction is based on majority. More involved methods weigh the votes of the base learners. \n",
-        "\n",
-        "Let us import some packages and define our figure of merit as accuracy in a balanced dataset."
-      ]
+    "colab": {},
+    "colab_type": "code",
+    "id": "07_F7WG4Kha4"
+   },
+   "outputs": [],
+   "source": [
+    "def nth_bit(idx, n):\n",
+    "    return (idx >> (num_nodes-n-1)) & 1\n",
+    "\n",
+    "def energy_from_wavefunction(wf):\n",
+    "  ZZ_filter = np.zeros_like(wf, dtype=float)\n",
+    "  for idx in range(len(wf)):\n",
+    "      for i in range(num_nodes):\n",
+    "         if nth_bit(idx, i):\n",
+    "             ZZ_filter[idx]+=h[i]\n",
+    "         for j in range(i+1, num_nodes):\n",
+    "             if nth_bit(idx, i) == nth_bit(idx, j):\n",
+    "                 ZZ_filter[idx] += J[i, j]\n",
+    "  return -np.sum(np.abs(wf)**2 * ZZ_filter) \n",
+    "\n",
+    "def energy_from_params(beta_gamma):\n",
+    "    beta = beta_gamma[0]\n",
+    "    gamma = beta_gamma[1]\n",
+    "    sim = cirq.Simulator()\n",
+    "    circuit = create_cirquit(beta, gamma)\n",
+    "    wf = sim.simulate(circuit).final_state_vector\n",
+    "    return energy_from_wavefunction(wf)\n",
+    "\n",
+    "result = minimize(energy_from_params,\n",
+    "                  [beta, gamma],\n",
+    "                  method='COBYLA')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "uEusNkedKhbB"
+   },
+   "source": [
+    "Finally, we extract the most likely solution:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2018-11-19T20:10:40.577140Z",
+     "start_time": "2018-11-19T20:10:40.571807Z"
     },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2018-11-19T20:10:18.000793Z",
-          "start_time": "2018-11-19T20:10:17.128450Z"
-        },
-        "id": "BRdEHzfcKhZ-",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "import matplotlib.pyplot as plt\n",
-        "import numpy as np\n",
-        "import sklearn\n",
-        "import sklearn.datasets\n",
-        "import sklearn.metrics\n",
-        "%matplotlib inline\n",
-        "\n",
-        "metric = sklearn.metrics.accuracy_score"
-      ],
-      "execution_count": 0,
-      "outputs": []
+    "colab": {},
+    "colab_type": "code",
+    "id": "KQUDnLo8KhbC"
+   },
+   "outputs": [],
+   "source": [
+    "final_circuit=create_cirquit(result.x[0], result.x[1])\n",
+    "print(final_circuit)\n",
+    "sim = cirq.Simulator()\n",
+    "wf = sim.simulate(circuit).final_state_vector\n",
+    "\n",
+    "k = np.argmax(wf)\n",
+    "weights = np.zeros(num_nodes)\n",
+    "for i in range(num_nodes):\n",
+    "    weights[i] = k % 2\n",
+    "    k >>= 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "9-b-hEaCKhbH"
+   },
+   "source": [
+    "Let's see the weights found by QAOA:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2018-11-19T20:10:40.597309Z",
+     "start_time": "2018-11-19T20:10:40.579449Z"
     },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "kivZQgMOKhaC",
-        "colab_type": "text"
-      },
-      "source": [
-        "We generate a random dataset of two classes that form concentric circles:"
-      ]
+    "colab": {},
+    "colab_type": "code",
+    "id": "mSAwxFTjKhbI"
+   },
+   "outputs": [],
+   "source": [
+    "weights"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "gquJUA7uKhbK"
+   },
+   "source": [
+    "And the final accuracy:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2018-11-19T20:10:40.614781Z",
+     "start_time": "2018-11-19T20:10:40.602793Z"
     },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2018-11-19T20:10:18.174692Z",
-          "start_time": "2018-11-19T20:10:18.003641Z"
-        },
-        "id": "gSzdAIAxKhaD",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "np.random.seed(0)\n",
-        "data, labels = sklearn.datasets.make_circles()\n",
-        "idx = np.arange(len(labels))\n",
-        "np.random.shuffle(idx)\n",
-        "# train on a random 2/3 and test on the remaining 1/3\n",
-        "idx_train = idx[:2*len(idx)//3]\n",
-        "idx_test = idx[2*len(idx)//3:]\n",
-        "X_train = data[idx_train]\n",
-        "X_test = data[idx_test]\n",
-        "\n",
-        "y_train = 2 * labels[idx_train] - 1  # binary -> spin\n",
-        "y_test = 2 * labels[idx_test] - 1\n",
-        "\n",
-        "scaler = sklearn.preprocessing.StandardScaler()\n",
-        "normalizer = sklearn.preprocessing.Normalizer()\n",
-        "\n",
-        "X_train = scaler.fit_transform(X_train)\n",
-        "X_train = normalizer.fit_transform(X_train)\n",
-        "\n",
-        "X_test = scaler.fit_transform(X_test)\n",
-        "X_test = normalizer.fit_transform(X_test)\n",
-        "plt.figure(figsize=(6, 6))\n",
-        "plt.subplot(111, xticks=[], yticks=[])\n",
-        "plt.scatter(data[labels == 0, 0], data[labels == 0, 1], color='navy')\n",
-        "plt.scatter(data[labels == 1, 0], data[labels == 1, 1], color='c')"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gIh74UIkKhaF",
-        "colab_type": "text"
-      },
-      "source": [
-        "Let's train a perceptron:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2018-11-19T20:10:18.226327Z",
-          "start_time": "2018-11-19T20:10:18.177561Z"
-        },
-        "id": "kv4kPmcAKhaG",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "from sklearn.linear_model import Perceptron\n",
-        "model_1 = Perceptron(max_iter=1000, tol=1e-3)\n",
-        "model_1.fit(X_train, y_train)\n",
-        "print('accuracy (train): %5.2f'%(metric(y_train, model_1.predict(X_train))))\n",
-        "print('accuracy (test): %5.2f'%(metric(y_test, model_1.predict(X_test))))"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "zfqHpvzWKhaJ",
-        "colab_type": "text"
-      },
-      "source": [
-        "Since its decision surface is linear, we get a poor accuracy. Would a support vector machine with a nonlinear kernel fare better?"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2018-11-19T20:10:18.244639Z",
-          "start_time": "2018-11-19T20:10:18.230025Z"
-        },
-        "id": "bdiY9DXQKhaK",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "from sklearn.svm import SVC\n",
-        "model_2 = SVC(kernel='rbf', gamma='auto')\n",
-        "model_2.fit(X_train, y_train)\n",
-        "print('accuracy (train): %5.2f'%(metric(y_train, model_2.predict(X_train))))\n",
-        "print('accuracy (test): %5.2f'%(metric(y_test, model_2.predict(X_test))))"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "sikwlkiXKhaM",
-        "colab_type": "text"
-      },
-      "source": [
-        "It performs better on the training set, but at the cost of extremely poor generalization. \n",
-        "\n",
-        "Boosting is an ensemble method that explicitly seeks models that complement one another. The variation between boosting algorithms is how they combine weak learners. Adaptive boosting (AdaBoost) is a popular method that combines the weak learners in a sequential manner based on their individual accuracies. It has a convex objective function that does not penalize for complexity: it is likely to include all available weak learners in the final ensemble. Let's train AdaBoost with a few weak learners:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2018-11-19T20:10:18.314089Z",
-          "start_time": "2018-11-19T20:10:18.248869Z"
-        },
-        "id": "03ZoTjmMKhaN",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "from sklearn.ensemble import AdaBoostClassifier\n",
-        "model_3 = AdaBoostClassifier(n_estimators=3)\n",
-        "model_3.fit(X_train, y_train)\n",
-        "print('accuracy (train): %5.2f'%(metric(y_train, model_3.predict(X_train))))\n",
-        "print('accuracy (test): %5.2f'%(metric(y_test, model_3.predict(X_test))))"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "9hVpr05sKhaQ",
-        "colab_type": "text"
-      },
-      "source": [
-        "Its performance is marginally better than that of the SVM."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "sos7cXfGKhaQ",
-        "colab_type": "text"
-      },
-      "source": [
-        "# QBoost\n",
-        "\n",
-        "The idea of Qboost is that optimization on a quantum computer is not constrained to convex objective functions, therefore we can add arbitrary penalty terms and rephrase our objective [[1](#1)]. Qboost solves the following problem:\n",
-        "\n",
-        "$$\n",
-        "\\mathrm{argmin}_{w} \\left(\\frac{1}{N}\\sum_{i=1}^{N}\\left(\\sum_{k=1}^{K}w_kh_k(x_i)-\n",
-        "y_i\\right)^2+\\lambda\\|w\\|_0\\right),\n",
-        "$$\n",
-        "\n",
-        "where $h_k(x_i)$ is the prediction of the weak learner $k$ for a training instance $k$. The weights in this formulation are binary, so this objective function already maps to an Ising model. The regularization in the $l_0$ norm ensures sparsity, and it is not the kind of regularization we would consider classically: it is hard to optimize with this term on a digital computer.\n",
-        "\n",
-        "Let us expand the quadratic part of the objective:\n",
-        "\n",
-        "$$\n",
-        "\\mathrm{argmin}_{w} \\left(\\frac{1}{N}\\sum_{i=1}^{N}\n",
-        "\\left( \\left(\\sum_{k=1}^{K} w_k h_k(x_i)\\right)^{2} -\n",
-        "2\\sum_{k=1}^{K} w_k h_k(\\mathbf{x}_i)y_i + y_i^{2}\\right) + \\lambda \\|w\\|_{0}\n",
-        "\\right).\n",
-        "$$\n",
-        "\n",
-        "Since $y_i^{2}$ is just a constant offset, the optimization reduces to\n",
-        "\n",
-        "$$\n",
-        "\\mathrm{argmin}_{w} \\left(\n",
-        "\\frac{1}{N}\\sum_{k=1}^{K}\\sum_{l=1}^{K} w_k w_l\n",
-        "\\left(\\sum_{i=1}^{N}h_k(x_i)h_l(x_i)\\right) - \n",
-        "\\frac{2}{N}\\sum_{k=1}^{K}w_k\\sum_{i=1}^{N} h_k(x_i)y_i +\n",
-        "\\lambda \\|w\\|_{0} \\right).\n",
-        "$$\n",
-        "\n",
-        "This form shows that we consider all correlations between the predictions of the weak learners: there is a summation of $h_k(x_i)h_l(x_i)$. Since this term has a positive sign, we penalize for correlations. On the other hand, the correlation with the true label, $h_k(x_i)y_i$, has a negative sign. The regularization term remains unchanged.\n",
-        "\n",
-        "\n",
-        "\n",
-        "To run this on an annealing machine we discretize this equation, reduce the weights to single bits, and normalize the estimator by K to scale with the feature data. As the weights are single bit, the regularization term becomes a summation that allows us to turn the expression into a QUBO.\n",
-        "\n",
-        "$$\n",
-        "\\mathrm{argmin}_{w} \\sum_{k=1}^{K} \\sum_{l=1}^{K}  w_kw_l \\sum_{i=1}^{N}\\frac{1}{K^2}h_k(x_i)h_l(x_i) + \\sum_{k=1}^{K}w_k \\left(\\lambda-2\\sum_{i=1}^{N} \\frac{1}{K}h_k(x_i)y_i   \\right), \\mathrm{w}_k \\in \\{0,1\\}\n",
-        "$$\n",
-        "\n",
-        "We split off the diagonal coefficients (k=l) in the left term and since $\\mathrm {w}\\in \\{0,1\\}$, and predictions, $\\mathrm h_k(x_i) \\in\\{-1,1\\}$ the following holds:\n",
-        "\n",
-        "$$\n",
-        "w_kw_k = w_k,\\;h_k(x_i)h_k(x_i) = 1\n",
-        "$$\n",
-        "\n",
-        "Hence:\n",
-        "\n",
-        "\n",
-        "$$\n",
-        "\\mathrm \\sum_{k=1}^{K}  w_kw_k \\sum_{i=1}^{N}\\frac{1}{K^2}h_k(x_i)h_k(x_i) = \\sum_{k=1}^{K}  w_k \\frac{N}{K^2}\n",
-        "$$\n",
-        "\n",
-        "This last term is effectively a fixed offset to $\\lambda $ \n",
-        "\n",
-        "$$\n",
-        "\\mathrm{argmin}_{w} \\sum_{k\\neq1}^{K}  w_kw_l \\left(\\sum_{i=1}^{N}\\frac{1}{K^2}h_k(x_i)h_l(x_i)\\right) + \\sum_{k=1}^{K}w_k \\left(\\frac{N}{K^2} +\\lambda-2\\sum_{i=1}^{N} \\frac{1}{K}h_k(x_i)y_i   \\right), \\mathrm{w}_k \\in \\{0,1\\}\n",
-        "$$\n",
-        "\n",
-        "The expressions between brackets are the coeficients of the QUBO\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "_g4dRvIEKhaR",
-        "colab_type": "text"
-      },
-      "source": [
-        "\n",
-        "Let us consider all three models from the previous section as weak learners."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2018-11-19T20:10:18.320974Z",
-          "start_time": "2018-11-19T20:10:18.316633Z"
-        },
-        "id": "7Xaw2_zEKhaS",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "models = [model_1, model_2, model_3]"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "BbvGvIT8KhaV",
-        "colab_type": "text"
-      },
-      "source": [
-        "We calculate their predictions and set $\\lambda$ to 1. "
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2018-11-19T20:10:18.354723Z",
-          "start_time": "2018-11-19T20:10:18.323802Z"
-        },
-        "id": "ePyav5gxKhaW",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "n_models = len(models)\n",
-        "predictions = np.array([h.predict(X_train) for h in models], dtype=np.float64)\n",
-        "λ = 1"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "b8R8AnjQKhaY",
-        "colab_type": "text"
-      },
-      "source": [
-        "We create the quadratic binary optimization of the objective function as we expanded above.\n",
-        "First the off-diagonal elements (see DWave's documentation for the sample_qubo() method ):\n",
-        "\n",
-        "$$\n",
-        "q_{ij} = \\sum_{i=1}^{N}\\frac{1}{K^2}h_k(x_i)h_l(x_i) \n",
-        "$$\n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2018-11-19T20:10:18.375760Z",
-          "start_time": "2018-11-19T20:10:18.357248Z"
-        },
-        "id": "AwhlEflrKhaZ",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "q = predictions @ predictions.T/(n_models ** 2)\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "_EGVfq2xKhac",
-        "colab_type": "text"
-      },
-      "source": [
-        "Then the diagonal elements:\n",
-        "\n",
-        "$$\n",
-        "\\mathrm q_{ii} =\\frac{N}{K^2}+ \\lambda-2\\sum_{i=1}^{N} \\frac{1}{K}h_k(x_i)y_i\n",
-        "$$\n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "UyFXB6bvKhad",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "qii = len(X_train) / (n_models ** 2) + λ - 2 * predictions @ y_train/(n_models)\n",
-        "\n",
-        "q[np.diag_indices_from(q)] = qii\n",
-        "Q = {}\n",
-        "for i in range(n_models):\n",
-        "    for j in range(i, n_models):\n",
-        "        Q[(i, j)] = q[i, j]"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "SpVm_3aJKhai",
-        "colab_type": "text"
-      },
-      "source": [
-        "We solve the quadratic binary optimization with simulated annealing and read out the optimal weights:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2018-11-19T20:10:18.703378Z",
-          "start_time": "2018-11-19T20:10:18.378217Z"
-        },
-        "id": "YzMtHbZ2Khaj",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "import dimod\n",
-        "sampler = dimod.SimulatedAnnealingSampler()\n",
-        "response = sampler.sample_qubo(Q, num_reads=10)\n",
-        "weights = list(response.first.sample.values())"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "QVTjUyn2Khan",
-        "colab_type": "text"
-      },
-      "source": [
-        "We define a prediction function to help with measuring accuracy:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2018-11-19T20:10:18.715360Z",
-          "start_time": "2018-11-19T20:10:18.705496Z"
-        },
-        "id": "Qq3jT-8MKhao",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "def predict(models, weights, X):\n",
-        "\n",
-        "    n_data = len(X)\n",
-        "    T = 0\n",
-        "    y = np.zeros(n_data)\n",
-        "    for i, h in enumerate(models):\n",
-        "        y0 = weights[i] * h.predict(X)  # prediction of weak classifier\n",
-        "        y += y0\n",
-        "        T += np.sum(y0)\n",
-        "\n",
-        "    y = np.sign(y - T / (n_data*len(models)))\n",
-        "\n",
-        "    return y"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2018-11-19T20:10:18.734604Z",
-          "start_time": "2018-11-19T20:10:18.719931Z"
-        },
-        "id": "3NDHjGUIKhar",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "print('accuracy (train): %5.2f'%(metric(y_train, predict(models, weights, X_train))))\n",
-        "print('accuracy (test): %5.2f'%(metric(y_test, predict(models, weights, X_test))))"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "-2K7jt1SKhat",
-        "colab_type": "text"
-      },
-      "source": [
-        "The accuracy co-incides with our strongest weak learner's, the AdaBoost model. Looking at the optimal weights, this is apparent:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2018-11-19T20:10:18.751765Z",
-          "start_time": "2018-11-19T20:10:18.736771Z"
-        },
-        "id": "72BFrpqjKhav",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "weights"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "e1G6CU6KKhax",
-        "colab_type": "text"
-      },
-      "source": [
-        "Only AdaBoost made it to the final ensemble. The first two models perform poorly and their predictions are correlated. Yet, if you remove regularization by setting $\\lambda=0$ above, the second model also enters the ensemble, decreasing overall performance. This shows that the regularization is in fact important."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "4DxoQ9CnKhay",
-        "colab_type": "text"
-      },
-      "source": [
-        "# Solving by QAOA\n",
-        "\n",
-        "Since eventually our problem is just an Ising model, we can also solve it on a gate-model quantum computer by QAOA. Let us explicitly map the binary optimization to the Ising model:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2018-11-19T20:10:18.765328Z",
-          "start_time": "2018-11-19T20:10:18.754605Z"
-        },
-        "id": "xSUgYnpjKhaz",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "h, J, offset = dimod.qubo_to_ising(Q)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "kGPlqhItKha1",
-        "colab_type": "text"
-      },
-      "source": [
-        "We have to translate the Ising couplings to be suitable for solving by the QAOA routine.  The following will create the QAOA circuit with functions from lesson 07 and initialize the QAOA circuit with initial values for beta and gamma."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "sPl5ZzTf2jeJ",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "import cirq\n",
-        "import numpy as np\n",
-        "from scipy.optimize import minimize\n",
-        "\n",
-        "qubits = cirq.LineQubit(i).range(q.shape[0])\n",
-        "num_nodes = len(qubits)\n",
-        "\n",
-        "def initial_layer(qubits):\n",
-        "    yield cirq.H.on_each(qubits)\n",
-        "\n",
-        "def beta_layer(beta, qubits):\n",
-        "    yield (cirq.X**(-beta)).on_each(qubits)\n",
-        "\n",
-        "def gamma_layer(gamma, qubits):\n",
-        "  for i in range(num_nodes):\n",
-        "    z_i = cirq.Z(qubits[i])\n",
-        "    yield np.exp(z_i * h[i] * gamma * 1j)\n",
-        "    for j in range(i+1, num_nodes):\n",
-        "        if q[i, j] != 0:\n",
-        "            z_j = cirq.Z(qubits[j])\n",
-        "            yield np.exp(z_i * z_j * J[i, j] * gamma * 1j)\n",
-        "\n",
-        "def create_cirquit(beta, gamma):\n",
-        "    return cirq.Circuit.from_ops(initial_layer(qubits),\n",
-        "                                 beta_layer(beta, qubits),\n",
-        "                                 gamma_layer(gamma, qubits))\n",
-        "\n",
-        "beta = np.random.uniform(0, 2 * np.pi)\n",
-        "gamma = np.random.uniform(0, 2 * np.pi)\n",
-        "circuit = create_cirquit(beta, gamma)\n",
-        "print(circuit)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "UyfJTMppKha3",
-        "colab_type": "text"
-      },
-      "source": [
-        "Next we run the optimization:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2018-11-19T20:10:40.568546Z",
-          "start_time": "2018-11-19T20:10:19.840830Z"
-        },
-        "id": "07_F7WG4Kha4",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "def nth_bit(idx, n):\n",
-        "    return (idx >> (num_nodes-n-1)) & 1\n",
-        "\n",
-        "def energy_from_wavefunction(wf):\n",
-        "  ZZ_filter = np.zeros_like(wf, dtype=float)\n",
-        "  for idx in range(len(wf)):\n",
-        "      for i in range(num_nodes):\n",
-        "         if nth_bit(idx, i):\n",
-        "             ZZ_filter[idx]+=h[i]\n",
-        "         for j in range(i+1, num_nodes):\n",
-        "             if nth_bit(idx, i) == nth_bit(idx, j):\n",
-        "                 ZZ_filter[idx] += J[i, j]\n",
-        "  return -np.sum(np.abs(wf)**2 * ZZ_filter) \n",
-        "\n",
-        "def energy_from_params(beta_gamma):\n",
-        "    beta = beta_gamma[0]\n",
-        "    gamma = beta_gamma[1]\n",
-        "    sim = cirq.Simulator()\n",
-        "    circuit = create_cirquit(beta, gamma)\n",
-        "    wf = sim.simulate(circuit).final_state\n",
-        "    return energy_from_wavefunction(wf)\n",
-        "\n",
-        "result = minimize(energy_from_params,\n",
-        "                  [beta, gamma],\n",
-        "                  method='COBYLA')\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "uEusNkedKhbB",
-        "colab_type": "text"
-      },
-      "source": [
-        "Finally, we extract the most likely solution:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2018-11-19T20:10:40.577140Z",
-          "start_time": "2018-11-19T20:10:40.571807Z"
-        },
-        "id": "KQUDnLo8KhbC",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "final_circuit=create_cirquit(result.x[0], result.x[1])\n",
-        "print(final_circuit)\n",
-        "sim = cirq.Simulator()\n",
-        "wf = sim.simulate(circuit).final_state\n",
-        "\n",
-        "k = np.argmax(wf)\n",
-        "weights = np.zeros(num_nodes)\n",
-        "for i in range(num_nodes):\n",
-        "    weights[i] = k % 2\n",
-        "    k >>= 1"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "9-b-hEaCKhbH",
-        "colab_type": "text"
-      },
-      "source": [
-        "Let's see the weights found by QAOA:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2018-11-19T20:10:40.597309Z",
-          "start_time": "2018-11-19T20:10:40.579449Z"
-        },
-        "id": "mSAwxFTjKhbI",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "weights"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gquJUA7uKhbK",
-        "colab_type": "text"
-      },
-      "source": [
-        "And the final accuracy:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "ExecuteTime": {
-          "end_time": "2018-11-19T20:10:40.614781Z",
-          "start_time": "2018-11-19T20:10:40.602793Z"
-        },
-        "id": "VJikRvvmKhbK",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "print('accuracy (train): %5.2f'%(metric(y_train, predict(models, weights, X_train))))\n",
-        "print('accuracy (test): %5.2f'%(metric(y_test, predict(models, weights, X_test))))"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "S2yz6KPsKhbM",
-        "colab_type": "text"
-      },
-      "source": [
-        "# References\n",
-        "\n",
-        "[1] Neven, H., Denchev, V.S., Rose, G., Macready, W.G. (2008). [Training a binary classifier with the quantum adiabatic algorithm](https://arxiv.org/abs/0811.0416). *arXiv:0811.0416*.  <a id='1'></a>"
-      ]
-    }
-  ]
+    "colab": {},
+    "colab_type": "code",
+    "id": "VJikRvvmKhbK"
+   },
+   "outputs": [],
+   "source": [
+    "print('accuracy (train): %5.2f'%(metric(y_train, predict(models, weights, X_train))))\n",
+    "print('accuracy (test): %5.2f'%(metric(y_test, predict(models, weights, X_test))))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "S2yz6KPsKhbM"
+   },
+   "source": [
+    "# References\n",
+    "\n",
+    "[1] Neven, H., Denchev, V.S., Rose, G., Macready, W.G. (2008). [Training a binary classifier with the quantum adiabatic algorithm](https://arxiv.org/abs/0811.0416). *arXiv:0811.0416*.  <a id='1'></a>"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "name": "09_Discrete_Optimization_and_Ensemble_Learning.ipynb",
+   "provenance": [],
+   "version": "0.3.2"
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/cirq_version/12_Training_Probabilistic_Graphical_Models.ipynb
+++ b/cirq_version/12_Training_Probabilistic_Graphical_Models.ipynb
@@ -196,7 +196,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -210,9 +210,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/cirq_version/13_Quantum_Phase_Estimation.ipynb
+++ b/cirq_version/13_Quantum_Phase_Estimation.ipynb
@@ -23,7 +23,8 @@
    "source": [
     "import numpy as np\n",
     "import cirq\n",
-    "from cirq import Circuit\n"
+    "from cirq import Circuit\n",
+    "from cirq_tools import *"
    ]
   },
   {
@@ -62,7 +63,7 @@
     "q0 = cirq.GridQubit(0,0)\n",
     "q1 = cirq.GridQubit(1,0)\n",
     "q2 = cirq.GridQubit(2,0)\n",
-    "qft = Circuit.from_ops(\n",
+    "qft = Circuit(\n",
     "    cirq.H(q0),\n",
     "    cirq.CZ(q1, q0)**0.5,\n",
     "    cirq.H(q1),\n",
@@ -143,7 +144,7 @@
     "q0 = cirq.GridQubit(0,0)\n",
     "q1 = cirq.GridQubit(1,0)\n",
     "ancilla = cirq.GridQubit(2,0)\n",
-    "qpe = Circuit.from_ops(\n",
+    "qpe = Circuit(\n",
     "    cirq.H(q0),\n",
     "    cirq.H(q1)\n",
     ")"
@@ -230,7 +231,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "qpe = Circuit.from_ops(\n",
+    "qpe = Circuit(\n",
     "    cirq.X(ancilla), # create |1> in the main register\n",
     "    cirq.H(q0),\n",
     "    cirq.H(q1),\n",
@@ -274,7 +275,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -288,7 +289,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.10.12"
   },
   "varInspector": {
    "cols": {
@@ -321,5 +322,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/cirq_version/14_Quantum_Matrix_Inversion.ipynb
+++ b/cirq_version/14_Quantum_Matrix_Inversion.ipynb
@@ -52,7 +52,7 @@
     "    matrix = np.array(\n",
     "      [[np.cos(t/2.0), -np.exp(1.0j*l)*np.sin(t/2.0)],\n",
     "       [np.exp(1.0j*p)*np.sin(t/2.0), np.exp(1.0j*(p+l))*np.cos(t/2.0)]])\n",
-    "    return cirq.SingleQubitMatrixGate(matrix=matrix)\n",
+    "    return cirq.MatrixGate(matrix=matrix)\n",
     "\n",
     "def cu3(t, p, l):\n",
     "    return cirq.ControlledGate(u3(t, p, l))\n",
@@ -64,7 +64,6 @@
     "    return cu3(0, 0, l)"
    ]
   },
-
   {
    "cell_type": "markdown",
    "metadata": {},
@@ -267,11 +266,11 @@
    "outputs": [],
    "source": [
     "# Target state preparation\n",
-    "hhl.append(cirq.Rz(-π).on(q[4]))\n",
+    "hhl.append(cirq.Rz(rads=-π).on(q[4]))\n",
     "hhl.append(u1(π).on(q[4]))\n",
     "hhl.append(cirq.H.on(q[4]))\n",
-    "hhl.append(cirq.Ry(-0.9311623288419387).on(q[4]))\n",
-    "hhl.append(cirq.Rz(π).on(q[4]))\n",
+    "hhl.append(cirq.Ry(rads=-0.9311623288419387).on(q[4]))\n",
+    "hhl.append(cirq.Rz(rads=π).on(q[4]))\n",
     "# Swap test\n",
     "hhl.append(cirq.H.on(q[5]))\n",
     "hhl.append(cirq.CNOT.on(q[4], q[3]))\n",
@@ -366,7 +365,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -380,9 +379,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+cirq-core==1.3.0
+cirq_google==1.3.0


### PR DESCRIPTION
Changes:
* `Circuit.from_ops` deprecated, replaced with calls to `Circuit` constructor.
* `XmonSimulator` deprecated, replaced with call to device with target gate set
* `SingleQubitMatrixGate` deprecated, replaced with `MatrixGate`
* `cirq.gate_features.TwoQubit` deprecated, replaced with `Gate` with `_num_qubits_ ` set to 2.
* `to_unitary_matrix()` deprecated, replaced by call to `unitary()`.
* In result, `final_state` renamed to `final_state_vector`.
* Gates `Rx`, `Ry`, `Rz` now require argument `rads=` to be named.
* `measure` now requires argument `key=` to be named.
* Bristlecone device deprecatd, replaced by Sycamore.
